### PR TITLE
update handle for join interrupted

### DIFF
--- a/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientStream.java
+++ b/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientStream.java
@@ -135,7 +135,8 @@ public class ClientStream {
             try {
                 thread.join();
             } catch (InterruptedException e) {
-                logger.warn("exception occurred when join LogProxy exit: ", e);
+                logger.warn("ClientStream thread is interrupted: " + e.getMessage());
+                stop();
             }
         }
     }


### PR DESCRIPTION
When user kill a process which integrates logproxy-client, there will be a lot of useless messages.

```java
WARN  com.oceanbase.clogproxy.client.connection.ClientStream - exception occurred when join LogProxy exit: 
java.lang.InterruptedException: null
	at java.lang.Object.wait(Native Method) ~[na:1.8.0_302]
	at java.lang.Thread.join(Thread.java:1252) ~[na:1.8.0_302]
	at java.lang.Thread.join(Thread.java:1326) ~[na:1.8.0_302]
	at com.oceanbase.clogproxy.client.connection.ClientStream.join(ClientStream.java:136) ~[logproxy-client-1.0.1.jar:na]
	at com.oceanbase.clogproxy.client.LogProxyClient.join(LogProxyClient.java:88) [logproxy-client-1.0.1.jar:na]
	at com.alibaba.otter.canal.parse.inbound.oceanbase.logproxy.LogProxyConnection.dump(LogProxyConnection.java:115) [classes/:na]
	at com.alibaba.otter.canal.parse.inbound.oceanbase.AbstractOceanBaseEventParser.dump(AbstractOceanBaseEventParser.java:53) [classes/:na]
	at com.alibaba.otter.canal.parse.inbound.AbstractEventParser.lambda$start$2(AbstractEventParser.java:185) [classes/:na]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_302]

```

We should remove these messages, and ensure that the connection is closed.