### PR TITLE
cleanup unnecessary dependencies

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -32,16 +32,8 @@ See the Mulan PSL v2 for more details.
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
     </dependency>
 
     <!-- SLF4J -->

--- a/logproxy-client/pom.xml
+++ b/logproxy-client/pom.xml
@@ -26,44 +26,22 @@ See the Mulan PSL v2 for more details.
   <description>The Client for OceanBase Log Proxy.</description>
 
   <dependencies>
+    <!-- common dependency -->
     <dependency>
       <groupId>com.oceanbase.logclient</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
     </dependency>
 
-    <!-- SLF4J -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jul-to-slf4j</artifactId>
-    </dependency>
-
-    <!-- logback -->
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/config/ObReaderConfig.java
+++ b/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/config/ObReaderConfig.java
@@ -11,12 +11,12 @@ See the Mulan PSL v2 for more details. */
 package com.oceanbase.clogproxy.client.config;
 
 
-import com.google.common.collect.Maps;
 import com.oceanbase.clogproxy.client.util.Validator;
 import com.oceanbase.clogproxy.common.config.SharedConf;
 import com.oceanbase.clogproxy.common.packet.LogType;
 import com.oceanbase.clogproxy.common.util.CryptoUtil;
 import com.oceanbase.clogproxy.common.util.Hex;
+import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +45,7 @@ public class ObReaderConfig extends AbstractConnectionConfig {
 
     /** Constructor with empty arguments. */
     public ObReaderConfig() {
-        super(Maps.newHashMap());
+        super(new HashMap<>());
     }
 
     /**

--- a/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientStream.java
+++ b/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientStream.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,7 +132,7 @@ public class ClientStream {
     /** Start the process thread. */
     public void start() {
         // if status listener exist, enable monitor
-        context.params.setEnableMonitor(CollectionUtils.isNotEmpty(statusListeners));
+        context.params.setEnableMonitor(!statusListeners.isEmpty());
 
         if (started.compareAndSet(false, true)) {
             thread =

--- a/logproxy-client/src/test/java/com/oceanbase/clogproxy/client/LogProxyClientTest.java
+++ b/logproxy-client/src/test/java/com/oceanbase/clogproxy/client/LogProxyClientTest.java
@@ -20,9 +20,13 @@ import io.netty.handler.ssl.SslContextBuilder;
 import javax.net.ssl.SSLException;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Ignore
 public class LogProxyClientTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(LogProxyClientTest.class);
 
     @Test
     public void testLogProxyClient() {
@@ -39,14 +43,14 @@ public class LogProxyClientTest {
                 new RecordListener() {
 
                     @Override
-                    public void notify(LogMessage record) {
-                        System.out.println(record);
+                    public void notify(LogMessage message) {
+                        logger.info("LogMessage received: {}", message.toString());
                     }
 
                     @Override
                     public void onException(LogProxyClientException e) {
                         if (e.needStop()) {
-                            System.out.println(e.getMessage());
+                            logger.error(e.getMessage());
                             client.stop();
                         }
                     }
@@ -70,14 +74,14 @@ public class LogProxyClientTest {
                 new RecordListener() {
 
                     @Override
-                    public void notify(LogMessage record) {
-                        System.out.println(record);
+                    public void notify(LogMessage message) {
+                        logger.info("LogMessage received: {}", message.toString());
                     }
 
                     @Override
                     public void onException(LogProxyClientException e) {
                         if (e.needStop()) {
-                            System.out.println(e.getMessage());
+                            logger.error(e.getMessage());
                             client.stop();
                         }
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,7 @@ See the Mulan PSL v2 for more details.
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <commons-lang.version>3.12.0</commons-lang.version>
-    <commons-collection.version>4.4</commons-collection.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <guava.version>31.0.1-jre</guava.version>
     <netty.version>4.1.68.Final</netty.version>
     <protobuf.version>3.18.2</protobuf.version>
     <lz4.version>1.8.0</lz4.version>
@@ -95,19 +93,9 @@ See the Mulan PSL v2 for more details.
         <version>${commons-lang.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-collections4</artifactId>
-        <version>${commons-collection.version}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
       </dependency>
 
       <!-- net -->
@@ -135,49 +123,18 @@ See the Mulan PSL v2 for more details.
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>log4j-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jul-to-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-
-      <!-- logback -->
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>slf4j-api</artifactId>
-            <groupId>org.slf4j</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>slf4j-log4j12</artifactId>
-            <groupId>org.slf4j</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
 
       <!-- test -->
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This project is used as a library, so it's unnecessary to import a slf4j logger implementation.
The apache collection and guava packages are used only in very few places, so I think it's better to remove them too.