### PR TITLE
fix & optimize ClientStream process

### DIFF
--- a/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientStream.java
+++ b/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientStream.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,16 +29,14 @@ import org.slf4j.LoggerFactory;
 public class ClientStream {
     private static final Logger logger = LoggerFactory.getLogger(ClientStream.class);
 
+    /** Context of stream. */
+    private final StreamContext context;
+
     /** Flag of whether the stream is started. */
     private final AtomicBoolean started = new AtomicBoolean(false);
+
     /** The process thread. */
     private Thread thread = null;
-
-    /** Context of stream. */
-    private StreamContext context;
-
-    /** Checkpoint string used to resume writing into the queue. */
-    private String checkpointString;
 
     /** Number of reconnections */
     private int retryTimes = 0;
@@ -79,10 +76,10 @@ public class ClientStream {
         this.context = new StreamContext(this, clientConf, connectionParams);
     }
 
-    /** Close and wait the connection. */
+    /** Close the connection and wait the process thread. */
     public void stop() {
-        if (!started.compareAndSet(true, false)) {
-            logger.info("stopping LogProxy Client....");
+        if (started.compareAndSet(true, false)) {
+            logger.info("Try to stop this client");
 
             if (connection != null) {
                 connection.close();
@@ -91,8 +88,8 @@ public class ClientStream {
 
             join();
             thread = null;
+            logger.info("Client stopped successfully");
         }
-        logger.info("stopped LogProxy Client");
     }
 
     /** Call {@link Thread#join()} method of process thread. */
@@ -101,8 +98,8 @@ public class ClientStream {
             try {
                 thread.join();
             } catch (InterruptedException e) {
-                logger.warn("ClientStream thread is interrupted: " + e.getMessage());
-                stop();
+                logger.warn("Waits for process thread failed : {}", e.getMessage());
+                triggerStop();
             }
         }
     }
@@ -140,11 +137,10 @@ public class ClientStream {
                                 while (isRunning()) {
                                     ReconnectState state = reconnect();
                                     if (state == ReconnectState.EXIT) {
-                                        logger.error("read thread to exit");
                                         triggerException(
                                                 new LogProxyClientException(
                                                         ErrorCode.E_MAX_RECONNECT,
-                                                        "exceed max reconnect retry"));
+                                                        "Exceed max retry times"));
                                         break;
                                     }
                                     if (state == ReconnectState.RETRY) {
@@ -157,8 +153,8 @@ public class ClientStream {
                                         continue;
                                     }
 
-                                    StreamContext.TransferPacket packet;
-                                    while (true) {
+                                    StreamContext.TransferPacket packet = null;
+                                    while (isRunning()) {
                                         try {
                                             packet =
                                                     context.recordQueue()
@@ -193,33 +189,24 @@ public class ClientStream {
                                                                 + packet.getType());
                                         }
                                     } catch (LogProxyClientException e) {
-                                        triggerStop();
                                         triggerException(e);
-                                        return;
-
+                                        break;
                                     } catch (Exception e) {
-                                        // if exception occurred, we exit
-                                        triggerStop();
                                         triggerException(
                                                 new LogProxyClientException(ErrorCode.E_USER, e));
-                                        return;
+                                        break;
                                     }
                                 }
 
-                                started.set(false);
-                                if (connection != null) {
-                                    connection.close();
-                                }
-                                thread = null;
-
-                                // TODO... if exception occurred, run handler callback
-
-                                logger.warn("!!! read thread exit !!!");
+                                triggerStop();
+                                logger.info("Client process thread exit");
                             });
 
             thread.setDaemon(false);
             thread.start();
         }
+        // add a shutdown hook to trigger the stop the process
+        Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
     }
 
     /**
@@ -239,54 +226,46 @@ public class ClientStream {
     private ReconnectState reconnect() {
         // reconnect flag mark, tiny load for checking
         if (reconnect.compareAndSet(true, false)) {
-            logger.warn("start to reconnect...");
+            logger.info("Try to reconnect");
+
+            // return when the limit of reconnect times id reached
+            if (context.config().getMaxReconnectTimes() != -1
+                    && retryTimes >= context.config().getMaxReconnectTimes()) {
+                logger.error(
+                        "Failed to reconnect, exceed max reconnect retry time: {}",
+                        context.config().getMaxReconnectTimes());
+                return ReconnectState.EXIT;
+            }
+
+            if (connection != null) {
+                connection.close();
+                connection = null;
+            }
 
             try {
-                if (context.config().getMaxReconnectTimes() != -1
-                        && retryTimes >= context.config().getMaxReconnectTimes()) {
-                    logger.error(
-                            "failed to reconnect, exceed max reconnect retry time: {}",
-                            context.config().getMaxReconnectTimes());
-                    reconnect.set(true);
-                    return ReconnectState.EXIT;
-                }
-
-                if (connection != null) {
-                    connection.close();
-                    connection = null;
-                }
-                // when stopped, context.recordQueue may not empty, just use checkpointString to do
-                // reconnection.
-                if (StringUtils.isNotEmpty(checkpointString)) {
-                    logger.warn("reconnect set checkpoint: {}", checkpointString);
-                    context.params().updateCheckpoint(checkpointString);
-                }
                 connection = ConnectionFactory.instance().createConnection(context);
                 if (connection != null) {
-                    logger.warn("reconnect SUCC");
+                    logger.info("Reconnect successfully");
                     retryTimes = 0;
-                    reconnect.compareAndSet(true, false);
                     return ReconnectState.SUCCESS;
                 }
 
                 logger.error(
-                        "failed to reconnect, retry count: {}, max: {}",
+                        "Failed to reconnect, retry count: {}, max: {}",
                         ++retryTimes,
                         context.config().getMaxReconnectTimes());
                 // not success, retry next time
                 reconnect.set(true);
                 return ReconnectState.RETRY;
-
             } catch (Exception e) {
                 logger.error(
-                        "failed to reconnect, retry count: {}, max: {}, message: {}",
+                        "Failed to reconnect, retry count: {}, max: {}, message: {}",
                         ++retryTimes,
                         context.config().getMaxReconnectTimes(),
                         e);
                 // not success, retry next time
                 reconnect.set(true);
                 return ReconnectState.RETRY;
-
             } finally {
                 reconnecting.set(false);
             }

--- a/logproxy-client/src/test/java/com/oceanbase/clogproxy/client/LogProxyClientTest.java
+++ b/logproxy-client/src/test/java/com/oceanbase/clogproxy/client/LogProxyClientTest.java
@@ -50,10 +50,7 @@ public class LogProxyClientTest {
 
                     @Override
                     public void onException(LogProxyClientException e) {
-                        if (e.needStop()) {
-                            logger.error(e.getMessage());
-                            client.stop();
-                        }
+                        logger.error(e.getMessage());
                     }
                 });
         client.start();
@@ -83,10 +80,7 @@ public class LogProxyClientTest {
 
                     @Override
                     public void onException(LogProxyClientException e) {
-                        if (e.needStop()) {
-                            logger.error(e.getMessage());
-                            client.stop();
-                        }
+                        logger.error(e.getMessage());
                     }
                 });
         client.start();


### PR DESCRIPTION
1. Fix `ClientStream.stop()` 'if' check: Change `!started.compareAndSet(true, false)` to `started.compareAndSet(true, false)`
2. Add shutdown hook to trigger `ClientStream.stop()` when JVM process exit.