### PR TITLE
update checkpoint for record queue

### DIFF
--- a/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientHandler.java
+++ b/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientHandler.java
@@ -334,6 +334,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             while (true) {
                 try {
                     recordQueue.put(new StreamContext.TransferPacket(logMessage));
+                    stream.setCheckpointString(logMessage.getTimestamp());
                     break;
                 } catch (InterruptedException e) {
                     // do nothing

--- a/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientStream.java
+++ b/logproxy-client/src/main/java/com/oceanbase/clogproxy/client/connection/ClientStream.java
@@ -303,6 +303,15 @@ public class ClientStream {
     }
 
     /**
+     * Set checkpoint string.
+     *
+     * @param checkpointString Checkpoint string.
+     */
+    public void setCheckpointString(String checkpointString) {
+        this.checkpointString = checkpointString;
+    }
+
+    /**
      * Add a {@link RecordListener} to {@link #listeners}.
      *
      * @param recordListener A {@link RecordListener}.


### PR DESCRIPTION
Update checkpoint (timestamp) when put record to the queue, which can be used as start timestamp for reconnection.