### PR TITLE
update the default connectTimeoutMs to 60s

### DIFF
--- a/docs/quickstart/logproxy-client-tutorial-cn.md
+++ b/docs/quickstart/logproxy-client-tutorial-cn.md
@@ -256,7 +256,7 @@ LogProxy 客户端还可以通过 `ClientConf` 配置一些客户端行为相关
             <tr>
                 <td>connectTimeoutMs</td>
                 <td>否</td>
-                <td style="word-wrap: break-word;">5000</td>
+                <td style="word-wrap: break-word;">60000</td>
                 <td>Int</td>
                 <td>connectTimeoutMs</td>
                 <td>连接超时时间（以毫秒为单位）。</td>

--- a/docs/quickstart/logproxy-client-tutorial.md
+++ b/docs/quickstart/logproxy-client-tutorial.md
@@ -256,7 +256,7 @@ There are also some configurations for the client in `ClientConf`:
             <tr>
                 <td>connectTimeoutMs</td>
                 <td>false</td>
-                <td style="word-wrap: break-word;">5000</td>
+                <td style="word-wrap: break-word;">60000</td>
                 <td>Int</td>
                 <td>connectTimeoutMs</td>
                 <td>Connection timeout in milliseconds.</td>

--- a/oblogclient-logproxy/src/main/java/com/oceanbase/clogproxy/client/config/ClientConf.java
+++ b/oblogclient-logproxy/src/main/java/com/oceanbase/clogproxy/client/config/ClientConf.java
@@ -143,7 +143,7 @@ public class ClientConf extends SharedConf implements Serializable {
     /** ClientConf builder with default values. */
     public static class Builder {
         private int transferQueueSize = 20000;
-        private int connectTimeoutMs = 5000;
+        private int connectTimeoutMs = 60000;
         private int readWaitTimeMs = 2000;
         private int retryIntervalS = 2;
         private int maxReconnectTimes = -1;

--- a/oblogclient-logproxy/src/test/java/com/oceanbase/clogproxy/client/config/ClientConfTest.java
+++ b/oblogclient-logproxy/src/test/java/com/oceanbase/clogproxy/client/config/ClientConfTest.java
@@ -32,7 +32,7 @@ public class ClientConfTest {
     public void testBuilderDefaultValues() {
         ClientConf clientConf = ClientConf.builder().build();
         Assert.assertEquals(clientConf.getTransferQueueSize(), 20000);
-        Assert.assertEquals(clientConf.getConnectTimeoutMs(), 5000);
+        Assert.assertEquals(clientConf.getConnectTimeoutMs(), 60000);
         Assert.assertEquals(clientConf.getReadWaitTimeMs(), 2000);
         Assert.assertEquals(clientConf.getRetryIntervalS(), 2);
         Assert.assertEquals(clientConf.getMaxReconnectTimes(), -1);


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Increase the default value of connect timeout to reduce unnecessary failures.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
